### PR TITLE
Localize API endpoint

### DIFF
--- a/media/js/options.js
+++ b/media/js/options.js
@@ -1,6 +1,4 @@
 var TiledeskChatWP = {
-    apiUrl: 'https://api.tiledesk.com/v2/',
-    chatUrl: 'https://www.tiledesk.com/',
     token: null,
     setRedirectLink: function (url) {
         jQuery('a[href="admin.php?page=tiledesk-chat"]')
@@ -34,7 +32,7 @@ var TiledeskChatWP = {
     getProjects: function (token) {
         jQuery.ajax({
             type: 'GET',
-            url: TiledeskChatWP.apiUrl + '/projects',
+            url: tiledesk_chat.api_url + '/projects',
             headers: { 'Authorization': token },
             success: function (response) {
                 console.log('response22', response)
@@ -79,7 +77,7 @@ var TiledeskChatWP = {
 
             login_button.prop('disabled', true).text('Loading...')
 
-            jQuery.post(TiledeskChatWP.apiUrl + 'auth/signin', {
+            jQuery.post(tiledesk_chat.api_url + 'auth/signin', {
                 email: email,
                 password: password,
             }, function (data) {
@@ -149,33 +147,6 @@ var TiledeskChatWP = {
                     login_button.trigger('click')
                 }
             })
-    },
-
-    // check this
-    accessTroughtXHR: function (_func) {
-        var xhr_url = TiledeskChatWP.apiUrl + '/access/external/create?url=' +
-            location.protocol + '//' + location.host + '&platform=wordpress'
-        jQuery.getJSON(xhr_url, {}, function (r) {
-            if (!r || !r.value) {
-                alert('Error occured while creating, please try again!')
-                return false
-            }
-            _func(
-                TiledeskChatWP.chatUrl + '/access?privateKey=' +
-                r.value.private_key +
-                '&app=chat&utm_source=platform&utm_medium=wordpress')
-            // save this in wordpress database
-            jQuery.post(ajaxurl, {
-                'action': 'tiledesk_chat_save_keys',
-                'public_key': r.value.public_key,
-                'private_key': r.value.private_key,
-            }, function (response) {
-
-            })
-
-        }).fail(function () {
-            alert('Error occured while creating, please try again!')
-        })
     },
 }
 

--- a/tiledesk-live-chat.php
+++ b/tiledesk-live-chat.php
@@ -15,6 +15,7 @@
 define( 'TILEDESKCHAT_VERSION', '1.0.4' );
 
 class TiledeskLiveChat {
+	const API_URL = 'https://api.tiledesk.com/v2/';
 	const CONSOLE_URL = 'https://console.tiledesk.com/v2/dashboard/#/project/';
 	const PUBLIC_KEY_OPTION = 'tiledesk-one-public-key';
 	const PRIVATE_KEY_OPTION = 'tiledesk-one-private-key';
@@ -161,8 +162,15 @@ class TiledeskLiveChat {
 	}
 
 	public function enqueue_admin_scripts() {
-		wp_enqueue_script( 'tiledesk-chat-admin', plugins_url( 'media/js/options.js', __FILE__ ), [], TILEDESKCHAT_VERSION, true );
 		wp_enqueue_style( 'tiledesk-chat-admin-style', plugins_url( 'media/css/options.css', __FILE__ ), [], TILEDESKCHAT_VERSION );
+		wp_enqueue_script( 'tiledesk-chat-admin', plugins_url( 'media/js/options.js', __FILE__ ), [], TILEDESKCHAT_VERSION, true );
+
+		// Allow URL override
+		$api_url = apply_filters( 'tiledesk_api_url', TiledeskLiveChat::API_URL );
+
+		wp_localize_script( 'tiledesk-chat-admin', 'tiledesk_chat', [
+			'api_url' => $api_url,
+		] );
 	}
 
 	/**


### PR DESCRIPTION
Use `wp_localize_script` to print API endpoint after `tiledesk_api_url` filter has been applied, fixing #1.